### PR TITLE
Improve link generation and config UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # paperless_tasks_integration
 Ein Tool das beim erstellen/ändern von paperless-Dokumenten einen Eintrag bei Google Tasks macht undn einen Bearbeitugnsstatus integriert
+
+## Konfiguration
+
+Die Anwendung liest ihre Einstellungen aus `config.json`. Neu hinzugekommen ist
+`SERVER_BASE_URL`, unter der der Flask-Server von extern erreichbar ist. Diese
+Adresse wird zum Aufbau der Links für den Statusdialog und den PDF-Viewer
+verwendet.
+
+Im Konfigurationsdialog werden die Google-Parameter (Client-ID, Secret,
+Token-Datei und Scopes) nicht mehr angezeigt, da diese üblicherweise nicht von
+Hand geändert werden.

--- a/config.json
+++ b/config.json
@@ -17,5 +17,6 @@
     "Gelöscht": "iJEaIedgGFmn72dI"
   },
   "SERVER_HOST": "0.0.0.0",
-  "SERVER_PORT": 8080
+  "SERVER_PORT": 8080,
+  "SERVER_BASE_URL": "http://localhost:8080"
 }

--- a/paperless_task_integration.py
+++ b/paperless_task_integration.py
@@ -47,7 +47,10 @@ if not os.path.exists(CONFIG_PATH):
             "Erledigt": "g6Nl8hQ56BDasAER",
             "keine Aktion": "WjcuDvnb9wWhkSEz",
             "Gelöscht": "iJEaIedgGFmn72dI"
-        }
+        },
+        "SERVER_HOST": "0.0.0.0",
+        "SERVER_PORT": 8080,
+        "SERVER_BASE_URL": "http://localhost:8080"
     })
 
 # ==== GOOGLE TASKS SERVICE ====
@@ -301,8 +304,9 @@ def paperless_webhook():
         return "Bereits erledigt", 200
     paperless_url = get_config("PAPERLESS_URL")
     link_webui = f"{paperless_url}/documents/{doc_id}/"
-    link_view_pdf = f"/view_pdf/{doc_id}"
-    status_link = f"/status/{doc_id}"
+    base_url = get_config("SERVER_BASE_URL", request.url_root.rstrip("/"))
+    link_view_pdf = f"{base_url}/view_pdf/{doc_id}"
+    status_link = f"{base_url}/status/{doc_id}"
     title = doc.get("title", "Paperless-Dokument")
     doc_type = doc.get("document_type")
     correspondent = doc.get("correspondent")
@@ -435,7 +439,10 @@ def config_ui():
     custom_fields = fetch_custom_fields()
 
     html_fields = ""
+    hidden_keys = {"GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET", "GOOGLE_TASKS_TOKEN", "SCOPES"}
     for key, value in config.items():
+        if key in hidden_keys:
+            continue
         if key == "ACTION_TASK_LIST_ID" and task_lists:
             options = ''.join([
                 f'<option value="{tl["id"]}"{" selected" if tl["id"]==value else ""}>{tl["title"]}</option>'


### PR DESCRIPTION
## Summary
- add `SERVER_BASE_URL` option to config
- build absolute URLs for PDF and status pages
- hide Google credentials in config UI
- document new setting in README

## Testing
- `python -m py_compile paperless_task_integration.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685942e75f70832fbee3acd9476a3afd