### PR TITLE
Improve link generation and config UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # paperless_tasks_integration
 Ein Tool das beim erstellen/ändern von paperless-Dokumenten einen Eintrag bei Google Tasks macht undn einen Bearbeitugnsstatus integriert
+
+## Konfiguration
+
+Die Anwendung liest ihre Einstellungen aus `config.json`. Neu hinzugekommen sind
+`SERVER_BASE_URL` (Basis-URL des Servers), `CUSTOM_FIELD_BEARBEITET` sowie die
+Parameter `STATUS_LABEL_NEW` und `STATUS_LABEL_DONE`. Damit lassen sich die
+Custom-Field-IDs und Bezeichnungen der Bearbeitungsstatus frei anpassen. Die
+Google-Token-Datei kann über `GOOGLE_TASKS_TOKEN` gewählt werden. Alle diese
+Werte werden beim Erzeugen von Links und beim Setzen der Statuswerte verwendet.
+
+Im Konfigurationsdialog werden die Google-Parameter (Client-ID, Secret,
+Token-Datei und Scopes) nicht mehr angezeigt, da diese üblicherweise nicht von
+Hand geändert werden.

--- a/config.json
+++ b/config.json
@@ -9,6 +9,7 @@
   "ACTION_THRESHOLD": 49,
   "CUSTOM_FIELD_STATUS": 4,
   "CUSTOM_FIELD_AKTION": 5,
+  "CUSTOM_FIELD_BEARBEITET": 3,
   "STATUS_LABEL_TO_ID": {
     "Unbearbeitet": "WBdb3hOCyFRkINdn",
     "Weitergeleitet": "mn1jNm0aR7zWhQgx",
@@ -17,5 +18,8 @@
     "Gelöscht": "iJEaIedgGFmn72dI"
   },
   "SERVER_HOST": "0.0.0.0",
-  "SERVER_PORT": 8080
+  "SERVER_PORT": 8080,
+  "SERVER_BASE_URL": "http://localhost:8080",
+  "STATUS_LABEL_NEW": "Unbearbeitet",
+  "STATUS_LABEL_DONE": "Erledigt"
 }


### PR DESCRIPTION
## Summary
- add `SERVER_BASE_URL` option to config
- build absolute URLs for PDF and status pages
- hide Google credentials in config UI
- document new setting in README
- load server info and status labels from config instead of hard-coding

## Testing
- `python -m py_compile paperless_task_integration.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685942e75f70832fbee3acd9476a3afd