### PR TITLE
Add OAuth config checks and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Die Anwendung liest ihre Einstellungen aus `config.json`. Wichtige Parameter sin
 
 Die Datei `config.example.json` enthält Beispielwerte und dient als Vorlage. Optional kann die Pfadangabe über die Umgebungsvariable `CONFIG_PATH` geändert werden.
 
+## Google OAuth einrichten
+Um Aufgaben in Google Tasks anlegen zu können, werden OAuth-Zugangsdaten benötigt.
+Diese lassen sich in der [Google Cloud Console](https://console.cloud.google.com/)
+erstellen:
+1. Ein neues Projekt anlegen oder ein vorhandenes wählen.
+2. Unter "APIs & Dienste" → "Anmeldedaten" einen OAuth-Client des Typs
+   "Desktop-App" erzeugen.
+3. Die ausgegebene `Client-ID` und das `Client-Secret` in der `config.json` unter
+   `GOOGLE_CLIENT_ID` bzw. `GOOGLE_CLIENT_SECRET` eintragen.
+Ohne diese Werte kann die Autorisierung nicht durchgeführt werden.
+
 ## Starten der Anwendung
 Nach dem Anpassen der Konfiguration kann der Server einfach mit
 

--- a/paperless_task_integration.py
+++ b/paperless_task_integration.py
@@ -356,11 +356,21 @@ def ensure_auth_for_ui():
 
 @app.route("/authorize")
 def authorize():
+    client_id = get_config("GOOGLE_CLIENT_ID")
+    client_secret = get_config("GOOGLE_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        html = (
+            "<h2>Google OAuth konfigurieren</h2>"
+            "<p>GOOGLE_CLIENT_ID und GOOGLE_CLIENT_SECRET "
+            "müssen in der config.json gesetzt sein.</p>"
+        )
+        return html, 500
+
     flow = Flow.from_client_config(
         {
             "installed": {
-                "client_id": get_config("GOOGLE_CLIENT_ID"),
-                "client_secret": get_config("GOOGLE_CLIENT_SECRET"),
+                "client_id": client_id,
+                "client_secret": client_secret,
                 "auth_uri": "https://accounts.google.com/o/oauth2/auth",
                 "token_uri": "https://oauth2.googleapis.com/token",
                 "redirect_uris": [url_for("oauth2callback", _external=True)],


### PR DESCRIPTION
## Summary
- validate `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` before starting OAuth flow
- document how to create Google OAuth credentials in README

## Testing
- `python3 -m py_compile paperless_task_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_6864f3a12c08832f911a76938e0d9efb