### PR TITLE
Fix duplicate tasks when items are moved to different lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Der Server lauscht standardmäßig unter `http://<SERVER_HOST>:<SERVER_PORT>/` u
 2. Der Server legt daraufhin eine Aufgabe in Google Tasks an, sofern das Dokument laut KI bearbeitet werden soll.
 3. Über die Statusseite kann der Bearbeitungsstatus geändert werden. Diese Änderung wird in Paperless gespeichert und in der verknüpften Google-Task-Notiz vermerkt.
 4. Ein Hintergrundjob prüft regelmäßig erledigte Aufgaben in Google Tasks und markiert die zugehörigen Paperless-Dokumente als erledigt.
+5. Der Server sucht in allen Google-Task-Listen nach vorhandenen Aufgaben, damit keine Duplikate entstehen, auch wenn Tasks verschoben werden.
 
 ## Weitere Hinweise
 - Für den Zugriff auf Google Tasks ist eine vorherige Authentifizierung notwendig. Das Token wird in der in `GOOGLE_TASKS_TOKEN` angegebenen Datei gespeichert.


### PR DESCRIPTION
## Summary
- search all Google Task lists for existing tasks to avoid duplicates
- update status sync logic to work across task lists
- note in README that all lists are scanned

## Testing
- `python3 -m py_compile paperless_task_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_686ec48214fc832fae6d3e57780c8523